### PR TITLE
babel-plugin-transform-runtime 패키지 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -906,6 +906,15 @@
         "regenerator-transform": "^0.10.0"
       }
     },
+    "babel-plugin-transform-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
@@ -2154,7 +2163,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "optional": true,
@@ -3791,7 +3800,7 @@
     },
     "jsesc": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist",
   "scripts": {
     "dev": "nodemon -w src --exec \"babel-node src --presets es2015,stage-0 --expose-debug-as=v8debug --inspect=127.0.0.1\"",
-    "build": "babel src -s -D -d dist --presets es2015,stage-0",
+    "build": "babel src -s -D -d dist --presets es2015,stage-0 --plugins transform-runtime",
     "start": "node dist",
     "prestart": "npm run -s build",
     "test": "eslint src"
@@ -57,6 +57,8 @@
     "babel-core": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-polyfill": "^6.26.0",
     "eslint": "^3.1.1",
     "mocha": "^5.2.0",
     "nodemon": "^1.9.2",

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ import passport from 'passport';
 import LocalStrategy from 'passport-local';
 import session from 'express-session';
 import UserModel from './models/loginCredential';
+import "babel-polyfill";
+import "babel-plugin-transform-runtime";
 
 let app = express();
 app.server = http.createServer(app);

--- a/src/lib/payments/index.js
+++ b/src/lib/payments/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 import fs from "fs";
 import axios from "axios";
 import apiCredential from "../../config/iamport";


### PR DESCRIPTION
**AS-IS**
`npm run dev`를 할 때는 문제가 없지만, `npm start`로 production에 환경으로 빌드 후 실행하면 `async` 구문을 Compile하지 못해 에러가 나면서 실행이 불가능

**TO-BE**
`bable-plugin-transform-runtime`(Babel 6)을 설치하고 실행시 `plugin` 목록을 추가해 줌

**Action Required**
`npm install` 한 번 씩 해줘야함

[참고링크](https://github.com/babel/babel-loader/issues/484)